### PR TITLE
Propagate analysis results to email generator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,16 @@ function App() {
       case 'database':
         return <DatabaseModule professorData={professorData} />;
       case 'analysis':
-        return <AnalysisModule professorData={professorData} />;
+        return (
+          <AnalysisModule
+            professorData={professorData}
+            onComplete={(analysisResults) =>
+              setProfessorData((prev: any) =>
+                prev ? { ...prev, analysisResults } : prev
+              )
+            }
+          />
+        );
       case 'email':
         return <EmailGenerator professorData={professorData} />;
       case 'dashboard':

--- a/src/components/AnalysisModule.tsx
+++ b/src/components/AnalysisModule.tsx
@@ -3,9 +3,10 @@ import { Brain, TrendingUp, Users, Heart, Eye, BarChart3, PieChart, Activity } f
 
 interface AnalysisModuleProps {
   professorData: any;
+  onComplete?: (results: Record<string, any>) => void;
 }
 
-const AnalysisModule: React.FC<AnalysisModuleProps> = ({ professorData }) => {
+const AnalysisModule: React.FC<AnalysisModuleProps> = ({ professorData, onComplete }) => {
   const [analysisResults, setAnalysisResults] = useState<any>({});
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [activeAnalysis, setActiveAnalysis] = useState<string[]>([]);
@@ -56,6 +57,8 @@ const AnalysisModule: React.FC<AnalysisModuleProps> = ({ professorData }) => {
     setAnalysisResults({});
     setActiveAnalysis([]);
 
+    const results: Record<string, any> = {};
+
     // Simuler l'exécution séquentielle des analyses
     for (const tool of analysisTools) {
       setActiveAnalysis(prev => [...prev, tool.name]);
@@ -65,10 +68,14 @@ const AnalysisModule: React.FC<AnalysisModuleProps> = ({ professorData }) => {
       
       // Générer des résultats simulés
       const result = generateAnalysisResult(tool.name, professorData);
+      results[tool.name] = result;
       setAnalysisResults(prev => ({ ...prev, [tool.name]: result }));
     }
 
     setIsAnalyzing(false);
+    if (onComplete) {
+      onComplete(results);
+    }
   };
 
   const generateAnalysisResult = (toolName: string, data: any) => {

--- a/src/components/EmailGenerator.tsx
+++ b/src/components/EmailGenerator.tsx
@@ -71,9 +71,9 @@ const EmailGenerator: React.FC<EmailGeneratorProps> = ({ professorData }) => {
   };
 
   const generatePersonalizedEmail = () => {
-    const analysisData = professorData.analysisResults || {};
-    const personalityInsights = analysisData['Deep Personal'] || {};
-    const characterProfile = analysisData['PsyCoT'] || {};
+    const analysisData = professorData?.analysisResults;
+    const personalityInsights = analysisData?.['Deep Personal'];
+    const characterProfile = analysisData?.['PsyCoT'];
     
     const template = `Objet: Opportunité unique de ${universityInfo.position} - ${universityInfo.name}
 
@@ -83,7 +83,7 @@ J'espère que ce message vous trouve en excellente santé et que vos recherches 
 
 ## Reconnaissance de votre expertise
 
-Votre travail remarquable, particulièrement vos ${professorData.academicInfo?.publications || 'nombreuses'} publications et vos ${professorData.academicInfo?.citations || 'nombreuses'} citations, a attiré notre attention. Votre approche ${personalityInsights.communicationStyle || 'innovante'} et votre style de leadership ${characterProfile.characterProfile?.workStyle || 'collaboratif'} correspondent parfaitement à la culture de notre institution.
+Votre travail remarquable, particulièrement vos ${professorData.academicInfo?.publications || 'nombreuses'} publications et vos ${professorData.academicInfo?.citations || 'nombreuses'} citations, a attiré notre attention. Votre approche ${personalityInsights?.communicationStyle || 'innovante'} et votre style de leadership ${characterProfile?.characterProfile?.workStyle || 'collaboratif'} correspondent parfaitement à la culture de notre institution.
 
 ## Opportunité proposée
 
@@ -95,9 +95,9 @@ ${universityInfo.benefits.split('\n').map(benefit => `• ${benefit.trim()}`).fi
 
 Basé sur notre analyse de votre profil professionnel :
 
-${personalityInsights.recommendedApproach ? `• **Approche personnalisée** : ${personalityInsights.recommendedApproach}` : ''}
-${characterProfile.recruitmentFit ? `• **Compatibilité élevée** : Score de ${characterProfile.recruitmentFit}% d'adéquation avec notre environnement` : ''}
-${characterProfile.characterProfile?.motivationFactors ? `• **Alignement des objectifs** : Nos opportunités correspondent à vos motivations : ${characterProfile.characterProfile.motivationFactors.join(', ')}` : ''}
+${personalityInsights?.recommendedApproach ? `• **Approche personnalisée** : ${personalityInsights.recommendedApproach}` : ''}
+${characterProfile?.recruitmentFit ? `• **Compatibilité élevée** : Score de ${characterProfile.recruitmentFit}% d'adéquation avec notre environnement` : ''}
+${characterProfile?.characterProfile?.motivationFactors ? `• **Alignement des objectifs** : Nos opportunités correspondent à vos motivations : ${characterProfile.characterProfile.motivationFactors.join(', ')}` : ''}
 
 ## Notre engagement envers l'excellence
 


### PR DESCRIPTION
## Summary
- add an `onComplete` callback to `AnalysisModule` and invoke it after all tools finish running
- merge returned analysis results into `professorData` from `App`
- read populated `professorData.analysisResults` in `EmailGenerator` without falling back to empty data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a3ef0c74832295b7cb89d2b1fd9d